### PR TITLE
Fix fullPrice unmarshaling and update ReduceTradeSize function

### DIFF
--- a/trades.go
+++ b/trades.go
@@ -62,19 +62,19 @@ type ModifiedTrade struct {
 		Time      time.Time `json:"time"`
 	} `json:"orderCreateTransaction"`
 	OrderFillTransaction struct {
-		Type           string `json:"type"`
-		Instrument     string `json:"instrument"`
-		Units          string `json:"units"`
-		Price          string `json:"price"`
-		FullPrice      string `json:"fullPrice"`
-		PL             string `json:"pl"`
-		Financing      string `json:"financing"`
-		Commission     string `json:"commission"`
-		AccountBalance string `json:"accountBalance"`
-		TradeOpened    string `json:"tradeOpened"`
-		TimeInForce    string `json:"timeInForce"`
-		PositionFill   string `json:"positionFill"`
-		Reason         string `json:"reason"`
+		Type           string    `json:"type"`
+		Instrument     string    `json:"instrument"`
+		Units          string    `json:"units"`
+		Price          string    `json:"price"`
+		FullPrice      FullPrice `json:"fullPrice"`
+		PL             string    `json:"pl"`
+		Financing      string    `json:"financing"`
+		Commission     string    `json:"commission"`
+		AccountBalance string    `json:"accountBalance"`
+		TradeOpened    string    `json:"tradeOpened"`
+		TimeInForce    string    `json:"timeInForce"`
+		PositionFill   string    `json:"positionFill"`
+		Reason         string    `json:"reason"`
 		TradesClosed   []struct {
 			TradeID    string `json:"tradeID"`
 			Units      string `json:"units"`
@@ -109,6 +109,19 @@ type ModifiedTrade struct {
 	} `json:"orderCancelTransaction"`
 	RelatedTransactionIDs []string `json:"relatedTransactionIDs"`
 	LastTransactionID     string   `json:"lastTransactionID"`
+}
+
+type FullPrice struct {
+	CloseoutBid string       `json:"closeoutBid"`
+	CloseoutAsk string       `json:"closeoutAsk"`
+	Timestamp   string       `json:"timestamp"`
+	Bids        []PriceLevel `json:"bids"`
+	Asks        []PriceLevel `json:"asks"`
+}
+
+type PriceLevel struct {
+	Price     string `json:"price"`
+	Liquidity string `json:"liquidity"`
 }
 
 func (c *Connection) GetTradesForInstrument(instrument string) (ReceivedTrades, error) {
@@ -149,7 +162,8 @@ func (c *Connection) ReduceTradeSize(ticket string, body CloseTradePayload) (Mod
 		"/accounts/"+
 			c.accountID+
 			"/trades/"+
-			ticket,
+			ticket+
+			"/close",
 		body,
 		&mt,
 	)


### PR DESCRIPTION
Description:
This PR addresses two issues in the goanda package:

1. Fixes the unmarshal error for the `fullPrice` field in the `OrderFillTransaction` struct. 
    - Related Error: ```json: cannot unmarshal object into Go struct field .orderFillTransaction.fullPrice of type string```

3. Corrects the URL in the `ReduceTradeSize` function to include the "/close" endpoint.

Changes:

1. Updated `OrderFillTransaction` struct:
   - Changed `FullPrice` field from `string` to custom `FullPrice` type

3. Added new structs:
   - `FullPrice`: to handle the complex fullPrice object
   - `PriceLevel`: to represent bid/ask price levels

4. Updated `ReduceTradeSize` function:
   - Added "/close" to the API endpoint URL as noted in the API documentation 

These changes resolve the JSON unmarshaling error for the `fullPrice` field and ensure that the `ReduceTradeSize` function correctly calls the trade closure endpoint.

Testing:
- Verified successful unmarshaling of API responses containing `fullPrice` data
- Confirmed that `ReduceTradeSize` function now correctly closes trades

Note: Users of this package may need to update their code if they directly access the `FullPrice` field of `OrderFillTransaction` or use the ReduceTradeSize function and rely on a err != nil condition